### PR TITLE
Add trailing null byte to JSON output

### DIFF
--- a/bin/codeclimate-prospector
+++ b/bin/codeclimate-prospector
@@ -15,7 +15,7 @@ for parsed in output['messages']:
       "description": parsed['message'],
       "categories": ["Bug Risk"],
       "location": parsed['location']
-    })
+    }) + "\x00"
 
 
 


### PR DESCRIPTION
This adds the trailing null byte to JSON output, which makes the engine work properly with the codeclimate CLI formatter.
