### PR TITLE
adding numpy install to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM masschallenge/python:v1.0.2
 
 MAINTAINER masschallenge dev team <dev@masschallenge.org>
 
+RUN apk add py-pip py-numpy --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
+
 WORKDIR /usr/src/app
 
 RUN pip install pep8 pylint pylint-django django_linter flake8 simplejson prospector[with_everything]


### PR DESCRIPTION
re-build codelimate engine and witness - numpy error no longer occurs.
